### PR TITLE
Allocate Leftover + some minor bug fixes

### DIFF
--- a/allocation/algorithms/stableMatching.ts
+++ b/allocation/algorithms/stableMatching.ts
@@ -77,7 +77,6 @@ export function stableMatching(
             }
         }
     }
-    console.log(`length of leftover:  ${leftOver.length}`)
     // change format to Allocation[]
     const arr: Allocation[] = Array.from(allocationResult.values()).map(projectAllocation => ({
         project: projectAllocation.project,
@@ -89,7 +88,17 @@ export function stableMatching(
         al.applicants = al.applicants.map(applicant => copyApplicant.find(a => a.id === applicant.id)!)
     }
 
-    console.log("Leftover")
+    for (const tempAllocation of arr) {
+        while (tempAllocation.applicants.length < projectTeamSize) {
+            const app = leftOver.shift();
+            if (!app) {
+                break;
+            }
+            tempAllocation.applicants.push(app)
+        }
+    }
+
+    console.log(`length of leftover:  ${leftOver.length}`)
     for (const app of leftOver) {
         const a = copyApplicant.find(a => a.id === app.id)
         if (!a) {

--- a/allocation/helper/utils.ts
+++ b/allocation/helper/utils.ts
@@ -33,7 +33,7 @@ export function logAllocationRankingList(allocations: Allocation[], baselineAllo
         console.log(`  3  (${temp[3].length}): ${temp[3].join(", ")}`);
         console.log(`  4  (${temp[4].length}): ${temp[4].join(", ")}`);
         console.log(`  5  (${temp[5].length}): ${temp[5].join(", ")}`);
-        console.log(`  6+ (${temp[0].length}): ${temp[0].join(", ")}`);
+        console.log(`  -1 (${temp[0].length}): ${temp[0].join(", ")}`);
     }
 
     // Final Output

--- a/allocation/index.ts
+++ b/allocation/index.ts
@@ -22,8 +22,8 @@ const allocate = async () => {
 
     // Algorithm
     console.log("Parsed! Running allocation algorithm...");
-    // const allocations = stableMatching(applicants, projectsData);
-    const allocations = randomHeuristicAscent(applicants, projectsData);
+    const allocations = stableMatching(applicants, projectsData);
+    // const allocations = randomHeuristicAscent(applicants, projectsData);
     // const allocations = powerOfFriendship(applicants, projectsData);
 
     const randomAllocations = randomlyAllocate(projectsData, applicants);

--- a/config.ts
+++ b/config.ts
@@ -6,7 +6,7 @@ export const config = {
         outFileFlagged: "./data/flaggedApplicants.csv",
     },
     allocation: {
-        inFileApplicants: "./data/applicants.csv",
+        inFileApplicants: "./data/processedApplicants.csv",
         inFileTeams: "./data/projectsData.csv",
         outFileFormat: "./data/out/applicants-<team>.csv",
         // Arbitrary constants to control objective function weighting


### PR DESCRIPTION
Applicants that are leftover after allocation are now allocated to the non-full projects (for ease of heuristic descent and manual swapping).

- there are also some minor bug fixes in this PR (namely the one with the wrong input filename in config and having 6+ instead of -1 for those that didn't get the project they wanted)